### PR TITLE
adding the possibility to test all classes in the package at once

### DIFF
--- a/src/main/java/com/objectpartners/AdditionalTransfer.java
+++ b/src/main/java/com/objectpartners/AdditionalTransfer.java
@@ -1,0 +1,16 @@
+package com.objectpartners;
+
+
+public class AdditionalTransfer {
+
+    private String someProperty;
+
+    public String getSomeProperty() {
+        return someProperty;
+    }
+
+    public void setSomeProperty(String someProperty) {
+        this.someProperty = someProperty;
+    }
+
+}

--- a/src/test/java/com/objectpartners/AllDtoInPackageTest.java
+++ b/src/test/java/com/objectpartners/AllDtoInPackageTest.java
@@ -1,0 +1,95 @@
+package com.objectpartners;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.reflect.ClassPath;
+import com.google.common.reflect.ClassPath.ClassInfo;
+
+/**
+* Convenience test case base that considers all classes in the package to be Dto's. 
+*/
+public abstract class AllDtoInPackageTest {
+
+    private static final Class JUNIT_TEST = Test.class;
+    private final Map<Class<?>, Supplier<?>> mappers;
+
+    public AllDtoInPackageTest() {
+        this.mappers = Collections.<Class<?>, Supplier<?>> emptyMap();
+    }
+
+    public AllDtoInPackageTest(Map<Class<?>, Supplier<?>> mappers) {
+        final ImmutableMap.Builder<Class<?>, Supplier<?>> builder = ImmutableMap.builder();
+        builder.putAll( mappers );
+        this.mappers = builder.build();
+    }
+
+    protected Set<Class<?>> classesToExclude() {
+        return new HashSet<>();
+    }
+
+    @Test
+    public void testAllDtoInPackage() throws Exception {
+        Set<Class<?>> classesToExclude = classesToExclude();
+
+        ClassPath cp = ClassPath.from( getClass().getClassLoader() );
+        for ( ClassInfo ci : cp.getTopLevelClasses( getClass().getPackage()
+                                                              .getName() ) ) {
+            Class classToTest = Class.forName( ci.getName() );
+            if ( !classesToExclude.contains( classToTest )
+                    && !isTestCase( classToTest )
+                    && !isAbstract( classToTest )
+                    && hasParameterlessConstructor( classToTest ) ) {
+                System.out.println( "testing: " + ci.getName() );
+                new InternalDtoTest( classToTest.newInstance(), mappers ).testGettersAndSetters();
+            }
+        }
+    }
+
+    private boolean isTestCase(Class clazz) {
+        for ( Method method : clazz.getMethods() ) {
+            if ( method.getAnnotationsByType( JUNIT_TEST ).length > 0 ) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean hasParameterlessConstructor(Class<?> clazz) {
+        return Stream.of( clazz.getConstructors() )
+                     .anyMatch( (c) -> c.getParameterCount() == 0 );
+    }
+
+    private boolean isAbstract(Class<?> clazz) {
+        return Modifier.isAbstract( clazz.getModifiers() );
+    }
+
+    private static class InternalDtoTest<T> extends DtoTest<T> {
+
+        private final T instance;
+
+        public InternalDtoTest(T instance, Map<Class<?>, Supplier<?>> customMappers) {
+            super( customMappers, null );
+            this.instance = instance;
+        }
+
+        public InternalDtoTest(T instance) {
+            this.instance = instance;
+        }
+
+        @Override
+        protected T getInstance() {
+            return instance;
+        }
+
+    }
+}

--- a/src/test/java/com/objectpartners/PackageTest.java
+++ b/src/test/java/com/objectpartners/PackageTest.java
@@ -1,0 +1,20 @@
+package com.objectpartners;
+
+import com.google.common.collect.ImmutableSet;
+import java.util.Set;
+
+/**
+ * Tests all the Dto's in the package.
+ *
+ * Test classes themselves are skipped, based on the condition that they have a public, @Test annotated method.
+ * However, for the {@link GetterSetterPair} there's no such condition so it's excluded explicitely.
+ */
+public class PackageTest extends AllDtoInPackageTest {
+
+    @Override
+    protected Set<Class<?>> classesToExclude() {
+        return ImmutableSet.of( GetterSetterPair.class );
+    }
+
+
+}


### PR DESCRIPTION
@Blastman I found your example really useful and extended a little bit on it to make it even more easy to use for my own. Typically I have all my `Dto`'s in one package. Being lazy, I just want to have a marker test case  for the entire package. Perhaps you can incorporate it in your example, even improve it. Perhaps not :smile:. Just wanted to share it.

-----

By the way: the provider can be very easily combined with a mocking framework like Mockito. See my example below for a `Dto` (`Geometry`) that needs to be made via a factory, but might as well be mocked.

```java
import static org.mockito.Mockito.mock;
 
import com.google.common.collect.ImmutableMap;
import com.vividsolutions.jts.geom.Geometry;
 
import nl.bro.common.testutil.dto.AllDtoInPackageTest;
 
public class AllDtoTest extends AllDtoInPackageTest {
 
    public AllDtoTest() {
        super( ImmutableMap.of( Geometry.class, () -> mock( Geometry.class ) ) );
    }
}
```

----
Anyway.. Thanks for sharing.
